### PR TITLE
Improve sync for HEIC files which SmugMug modifies server side

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ install_requires = [
   'hachoir-core>=1.3.3; python_version<"3.0"',
   'hachoir-metadata>=1.3.3; python_version<"3.0"',
   'hachoir-parser>=1.3.4; python_version<"3.0"',
-  'hachoir>=3.0a4; python_version>="3.0"'
+  'hachoir>=3.0; python_version>="3.0"',
+  'six>=1.15.0'
 ]
 
 with open("README.md", "r") as fh:

--- a/smugcli/smugmug_fs.py
+++ b/smugcli/smugmug_fs.py
@@ -410,10 +410,10 @@ class SmugMugFS(object):
       file_name = file_path.split(os.sep)[-1].strip()
       with open(file_path, 'rb') as f:
         file_content = f.read()
-      file_root, file_extension = os.path.splitext(filename)
+      file_root, file_extension = os.path.splitext(file_name)
       if file_extension.lower() == '.heic':
         # SmugMug converts HEIC files to JPEG and renames them in the process
-        renamed_file = '_' + file_extension[1:] + '.JPG'
+        renamed_file = file_root + '_' + file_extension[1:] + '.JPG'
         remote_file = node.get_child(renamed_file)
       else:
         remote_file = node.get_child(file_name)

--- a/smugcli/smugmug_fs.py
+++ b/smugcli/smugmug_fs.py
@@ -410,9 +410,10 @@ class SmugMugFS(object):
       file_name = file_path.split(os.sep)[-1].strip()
       with open(file_path, 'rb') as f:
         file_content = f.read()
-      if file_name.lower().endswith("heic"):
+      file_root, file_extension = os.path.splitext(filename)
+      if file_extension.lower() == '.heic':
         # SmugMug converts HEIC files to JPEG and renames them in the process
-        renamed_file = file_name.replace(".HEIC", "_HEIC.JPG")
+        renamed_file = '_' + file_extension[1:] + '.JPG'
         remote_file = node.get_child(renamed_file)
       else:
         remote_file = node.get_child(file_name)

--- a/smugcli/smugmug_fs.py
+++ b/smugcli/smugmug_fs.py
@@ -486,7 +486,6 @@ class SmugMugFS(object):
       return progress_fn
 
     with manager.start_task(0, task):
-      #print("No-op!")
       node.upload('Album', file_name, file_content,
                   progress_fn=get_progress_fn(task))
 


### PR DESCRIPTION
Improve syncing for HEIC files (created by iPhones now by default).

SmugMug converts these to JPEG and renames them with an "_HEIC" suffix.

This fix checks the correct remote name and uses the modified time as the check for changes.