### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/smugcli/smugmug_oauth.py
+++ b/smugcli/smugmug_oauth.py
@@ -68,7 +68,7 @@ class SmugMugOAuth(object):
         print('Could not start default browser automatically.')
         print('Please visit %s to complete login process.' % login_url)
 
-      while thread.isAlive():
+      while thread.is_alive():
         thread.join(1)
     finally:
       httpd.server_close()


### PR DESCRIPTION
Fixes #15 