### PR TITLE
smugmug_fs: handle SmugMug shenanigans that sometimes movie files

### DIFF
--- a/smugcli/smugmug_fs.py
+++ b/smugcli/smugmug_fs.py
@@ -428,6 +428,17 @@ class SmugMugFS(object):
         # SmugMug converts HEIC files to JPEG and renames them in the process
         renamed_file = file_root + '_' + file_extension[1:] + '.JPG'
         remote_file = node.get_child(renamed_file)
+      elif file_extension.lower() == '.mp4':
+        for renamed_file in (
+            (file_root + '_' + file_extension[1:] + '.MP4'),
+            (file_root + '.MP4'),
+            ):
+          maybe_remote_file = node.get_child(renamed_file)
+          if maybe_remote_file:
+            remote_file = maybe_remote_file
+            break
+        else:
+          remote_file = node.get_child(file_name)
       else:
         remote_file = node.get_child(file_name)
 


### PR DESCRIPTION
Experimentally FOO.mp4 can get renamed either to FOO_mp4.MP4 or
FOO.MP4. It's unclear what triggers this behavior (presumably
something about the video content, maybe something that triggers a
re-encode or re-mux), but this avoids duplicating the video on every
`smugcli sync` invocation for files that get renamed like this.

Fixes #21. (As far as I can tell.)