### PR TITLE
Add support for replacing images in-place during sync.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ colorama>=0.3.9; platform_system=="Windows"
 
 # For parsing metadata from local files:
 hachoir>=3.0
+
+# To query JSON content with `ls --query`:
+jsonpath-ng >= 1.5.3

--- a/smugcli/smugcli.py
+++ b/smugcli/smugcli.py
@@ -198,7 +198,8 @@ def run(args, config=None, requests_sent=None):
                                                   a.folder_threads,
                                                   a.file_threads,
                                                   a.upload_threads,
-                                                  a.set_defaults))
+                                                  a.set_defaults,
+                                                  a.in_place))
   sync_parser.add_argument('source',
                            type=arg_str_type,
                            nargs='*',
@@ -257,6 +258,10 @@ def run(args, config=None, requests_sent=None):
                            action='store_true',
                            help=('Save the current settings (thread count) as '
                                  'defaults to be used next time.'))
+  sync_parser.add_argument('--in_place',
+                           action='store_true',
+                           help=('Upload replacments in-place instead of '
+                                 'deleting and re-uploading.'))
 
   # ---------------
   ignore_parser = subparsers.add_parser(

--- a/smugcli/smugcli_commands.py
+++ b/smugcli/smugcli_commands.py
@@ -276,7 +276,7 @@ def run(args,
                                  'defaults to be used next time.'))
   sync_parser.add_argument('--in_place',
                            action='store_true',
-                           help=('Upload replacments in-place instead of '
+                           help=('Upload replacements in-place instead of '
                                  'deleting and re-uploading.'))
 
   # ---------------

--- a/smugcli/smugcli_commands.py
+++ b/smugcli/smugcli_commands.py
@@ -94,7 +94,7 @@ def run(args,
       help='List the content of a folder or album.',
       formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   ls_parser.set_defaults(
-      func=lambda a: file_system.ls(a.user, a.path, a.l))
+      func=lambda a: file_system.ls(a.user, a.path, a.l, a.query))
   ls_parser.add_argument('path',
                          type=str,
                          nargs='?',
@@ -111,6 +111,14 @@ def run(args,
                          default='',
                          help=('User whose SmugMug account is to be accessed. '
                                'Uses the logged-in user by default.'))
+  ls_parser.add_argument('-q', '--query',
+                         type=str,
+                         default='',
+                         help=('Fetch the full JSON description of the node '
+                               'and return the fields that are matching the '
+                               'specified query. See '
+                               'https://pypi.org/project/jsonpath-ng/ for '
+                               'the details on the query language.'))
   # ---------------
   for cmd, node_type in (('mkdir', 'Folder'), ('mkalbum', 'Album')):
     mkdir_parser = subparsers.add_parser(

--- a/smugcli/smugmug_fs.py
+++ b/smugcli/smugmug_fs.py
@@ -505,7 +505,7 @@ class SmugMugFS(object):
 
     with manager.start_task(0, task):
       additional_headers = None
-      if in_place:
+      if in_place and remote_file:
         additional_headers = {
           'X-Smug-ImageUri': remote_file.uri('Image'),
         }

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -524,6 +524,53 @@ class EndToEndTest(integration_test_base.IntegrationTestBase):
                   expect.Anything().repeatedly(),
                   'Found matching remote album "{root}/album".')])
 
+  def test_sync_in_place(self):
+    """Test the `--in_place` option of `smugcli sync`."""
+    self._stage_files('{root}/album', ['{testdata}/SmugCLI_1.jpg'])
+    self._do('sync {root}',
+             ['Syncing "{root}" to SmugMug folder "/".',
+              'Proceed (yes\\/no)?',
+              expect.Reply('yes'),
+              expect.AnyOrder(
+                  expect.Anything().repeatedly(),
+                  'Creating Folder "{root}".',
+                  'Creating Album "{root}/album".',
+                  'Uploaded "{root}/album/SmugCLI_1.jpg".')])
+
+    web_uri = self._do('ls -l -q WebUri {root}/album/SmugCLI_1.jpg')
+
+    self._stage_files(
+        '{root}/album/SmugCLI_1.jpg', ['{testdata}/SmugCLI_2.jpg'])
+    self._do('sync --in_place {root}',
+             ['Syncing "{root}" to SmugMug folder "/".',
+              'Proceed (yes\\/no)?',
+              expect.Reply('yes'),
+              expect.AnyOrder(
+                  expect.Anything().repeatedly(),
+                  'Found matching remote album "{root}/album".',
+                  'File "{root}/album/SmugCLI_1.jpg" exists, but has changed.'
+                  ' Upload in place.',
+                  'Re-uploaded "{root}/album/SmugCLI_1.jpg".')])
+
+    self._do('ls -l -q WebUri {root}/album/SmugCLI_1.jpg',
+             expect.Url(expect.Equals(web_uri)))
+
+    self._stage_files(
+        '{root}/album/SmugCLI_1.jpg', ['{testdata}/SmugCLI_3.jpg'])
+    self._do('sync {root}',
+             ['Syncing "{root}" to SmugMug folder "/".',
+              'Proceed (yes\\/no)?',
+              expect.Reply('yes'),
+              expect.AnyOrder(
+                  expect.Anything().repeatedly(),
+                  'Found matching remote album "{root}/album".',
+                  'File "{root}/album/SmugCLI_1.jpg" exists, but has changed.'
+                  ' Deleting old version.',
+                  'Re-uploaded "{root}/album/SmugCLI_1.jpg".')])
+
+    self._do('ls -l -q WebUri {root}/album/SmugCLI_1.jpg',
+             expect.Url(expect.Not(expect.Equals(web_uri))))
+
   def test_sync_sub_folders(self):
     """Test syncing to sub-folders."""
     self._stage_files('{root}/local/album', ['{testdata}/SmugCLI_1.jpg'])

--- a/tests/end_to_end_test.py
+++ b/tests/end_to_end_test.py
@@ -43,9 +43,17 @@ class EndToEndTest(integration_test_base.IntegrationTestBase):
     self._do('ls -l {root}',
              expect.Somewhere('"Name": "foo",'))
 
-    # Lists other user's folder
+    # Lists other user's folder:
     self._do('ls -u cmac',
              expect.Somewhere('Photography'))
+
+    # Query a field from the node's JSON:
+    self._do('ls -q "WebUri" {root}',
+             expect.Url(expect.Regex(r'https://.*/Foo')))
+
+    # Invalid query string:
+    self._do('ls -q foo^bar {root}',
+             expect.Contains('Invalid query string'))
 
   def test_mkdir(self):
     """Test for `smugcli mkdir`."""

--- a/tests/integration_test_base.py
+++ b/tests/integration_test_base.py
@@ -183,7 +183,7 @@ class IntegrationTestBase(unittest.TestCase):
           url=req['url'],
           callback=lambda x, rq=req, rs=resp, n=name: callback(x, rq, rs, n))
 
-  def _do(self, command: str, expected_io=None):
+  def _do(self, command: str, expected_io=None) -> str:
     command = self._format_path(command)
     print(f'$ {command}')
     self._io.set_expected_io(expected_io)
@@ -209,7 +209,7 @@ class IntegrationTestBase(unittest.TestCase):
       self._save_requests(cache_folder, requests_sent)
 
     self._command_index += 1
-    self._io.assert_expectations_fulfilled()
+    return self._io.assert_expectations_fulfilled().getvalue()
 
   def _stage_files(self, dest, files):
     dest_path = self._format_path(dest)

--- a/tests/io_expectation.py
+++ b/tests/io_expectation.py
@@ -700,7 +700,7 @@ class ExpectedInputOutput():
     self._original_stdout.write(reply)
     return reply
 
-  def assert_expectations_fulfilled(self):
+  def assert_expectations_fulfilled(self) -> io.StringIO:
     """Asserts that all expectation are fulfilled.
 
     Resets this object, ready to restart with a new set_expected_io.
@@ -708,6 +708,7 @@ class ExpectedInputOutput():
     Raises:
       AssertionError: raised when IOs do not match expectations.
     """
+    cmd_output = self._cmd_output
     self._match_pending_outputs()
     if self._expected_io:
       if not self._expected_io.fulfilled:
@@ -715,6 +716,7 @@ class ExpectedInputOutput():
                              self._expected_io.description(saturated=False))
 
     self.set_expected_io(None)
+    return cmd_output
 
   def assert_output_was(self, expected_output):
     """Asserts that the previous outputs matched the specified expectation.

--- a/tests/io_expectation.py
+++ b/tests/io_expectation.py
@@ -571,6 +571,29 @@ def Somewhere(expectation):  # pylint: disable=invalid-name
                  Anything().repeatedly())
 
 
+class Url(ExpectBase):
+  """Matches a URL. This matcher won't replace '/' to '\' on Windows."""
+
+  def __init__(self, sub_expectation):
+    super().__init__()
+    self._expected = default_expectation(sub_expectation)
+
+  def consume(self, string):
+    self._consumed = True
+    self._fulfilled = self._expected.consume(string)
+    self._saturated = self._expected.saturated
+    return self._fulfilled
+
+  def test_consume(self, string):
+    return self._expected.test_consume(string)
+
+  def apply_transform(self, callback: Callable[[str], str]) -> None:
+    del callback  # Unused.
+
+  def description(self, saturated):
+    return f'Url({self._expected.description(saturated)})'
+
+
 class Reply(ExpectBase):
   """Expects a read to the input pipe and replies with a specific string."""
 

--- a/tests/io_expectation_test.py
+++ b/tests/io_expectation_test.py
@@ -866,6 +866,35 @@ class IoExpectationTest(unittest.TestCase):
                        print('Some more output.')),
           error_message=None),
 
+      # ==== Url ====
+      param(
+          'expect_url_equals',
+          expected_io=expect.Url(expect.Equals('http://foo.com/bar')),
+          ios=lambda: print('http://foo.com/bar'),
+          error_message=None),
+
+      param(
+          'expect_url_equals_error',
+          expected_io=expect.Url(expect.Equals('http://foo.com/bar')),
+          ios=lambda: print('http://bar.com/bar'),
+          error_message=("Unexpected output:\n"
+                         "- Url(Equals('http://foo.com/bar'))\n"
+                         "+ 'http://bar.com/bar\\n'")),
+
+      param(
+          'expect_url_default_sub_expectation',
+          expected_io=expect.Url('foo.com'),
+          ios=lambda: print('http://foo.com/bar'),
+          error_message=None),
+
+      param(
+          'expect_url_in_order',
+          expected_io=expect.Url(['http://foo.com/for',
+                                  'http://bar.com/bar']),
+          ios=lambda: (print('http://foo.com/for'),
+                       print('http://bar.com/bar')),
+          error_message=None),
+
       # ==== Reply ====
       param(
           'expect_reply',


### PR DESCRIPTION
This allows images in an album to be updated in-place, without changing the identifiers and URLs that users may have shared or re-used elsewhere.